### PR TITLE
Add support for numeric keys in Map and OrderedMap

### DIFF
--- a/immutable/serialize.js
+++ b/immutable/serialize.js
@@ -9,8 +9,8 @@ module.exports = function serialize(Immutable, refs) {
       if (value instanceof Immutable.Record) return refer(value, 'ImmutableRecord', 'toObject', refs);
       if (value instanceof Immutable.Range) return extract(value, 'ImmutableRange');
       if (value instanceof Immutable.Repeat) return extract(value, 'ImmutableRepeat');
-      if (Immutable.OrderedMap.isOrderedMap(value)) return mark(value, 'ImmutableOrderedMap', 'toObject');
-      if (Immutable.Map.isMap(value)) return mark(value, 'ImmutableMap', 'toObject');
+      if (Immutable.OrderedMap.isOrderedMap(value)) return mark(value.entrySeq().toArray(), 'ImmutableOrderedMap');
+      if (Immutable.Map.isMap(value)) return mark(value.entrySeq().toArray(), 'ImmutableMap');
       if (Immutable.List.isList(value)) return mark(value, 'ImmutableList', 'toArray');
       if (Immutable.OrderedSet.isOrderedSet(value)) return mark(value, 'ImmutableOrderedSet', 'toArray');
       if (Immutable.Set.isSet(value)) return mark(value, 'ImmutableSet', 'toArray');

--- a/test/__snapshots__/immutable.spec.js.snap
+++ b/test/__snapshots__/immutable.spec.js.snap
@@ -1,12 +1,16 @@
-exports[`Immutable Nested stringify 1`] = `"{\"data\":[[\"map\",{\"data\":{\"seq\":{\"data\":[1,2,3,4,5,6,7,8],\"__serializedType__\":\"ImmutableSeq\"},\"stack\":{\"data\":[\"a\",\"b\",\"c\"],\"__serializedType__\":\"ImmutableStack\"}},\"__serializedType__\":\"ImmutableOrderedMap\"}],[\"repeat\",{\"data\":{\"_value\":\"hi\",\"size\":100},\"__serializedType__\":\"ImmutableRepeat\"}]],\"__serializedType__\":\"ImmutableSet\"}"`;
+exports[`Immutable Nested stringify 1`] = `"{\"data\":[[\"map\",{\"data\":[[\"seq\",{\"data\":[1,2,3,4,5,6,7,8],\"__serializedType__\":\"ImmutableSeq\"}],[\"stack\",{\"data\":[\"a\",\"b\",\"c\"],\"__serializedType__\":\"ImmutableStack\"}]],\"__serializedType__\":\"ImmutableOrderedMap\"}],[\"numeric_map\",{\"data\":[[1,{\"data\":[1,2,3,4,5,6,7,8],\"__serializedType__\":\"ImmutableSeq\"}],[2,{\"data\":[\"a\",\"b\",\"c\"],\"__serializedType__\":\"ImmutableStack\"}]],\"__serializedType__\":\"ImmutableMap\"}],[\"repeat\",{\"data\":{\"_value\":\"hi\",\"size\":100},\"__serializedType__\":\"ImmutableRepeat\"}]],\"__serializedType__\":\"ImmutableSet\"}"`;
 
 exports[`Immutable Record stringify 1`] = `"{\"data\":{\"a\":1,\"b\":3},\"__serializedType__\":\"ImmutableRecord\",\"__serializedRef__\":0}"`;
 
 exports[`Immutable Stringify list 1`] = `"{\"data\":[1,2,3,4,5,6,7,8,9,10],\"__serializedType__\":\"ImmutableList\"}"`;
 
-exports[`Immutable Stringify map 1`] = `"{\"data\":{\"a\":1,\"b\":2,\"c\":3,\"d\":4},\"__serializedType__\":\"ImmutableMap\"}"`;
+exports[`Immutable Stringify map 1`] = `"{\"data\":[[\"a\",1],[\"b\",2],[\"c\",3],[\"d\",4]],\"__serializedType__\":\"ImmutableMap\"}"`;
 
-exports[`Immutable Stringify orderedMap 1`] = `"{\"data\":{\"b\":2,\"a\":1,\"c\":3,\"d\":4},\"__serializedType__\":\"ImmutableOrderedMap\"}"`;
+exports[`Immutable Stringify numeric keys OrderedMap 1`] = `"{\"data\":[[1,\"one\"],[2,\"two\"],[3,\"three\"]],\"__serializedType__\":\"ImmutableOrderedMap\"}"`;
+
+exports[`Immutable Stringify numeric keys map 1`] = `"{\"data\":[[1,\"one\"],[2,\"two\"],[3,\"three\"]],\"__serializedType__\":\"ImmutableMap\"}"`;
+
+exports[`Immutable Stringify orderedMap 1`] = `"{\"data\":[[\"b\",2],[\"a\",1],[\"c\",3],[\"d\",4]],\"__serializedType__\":\"ImmutableOrderedMap\"}"`;
 
 exports[`Immutable Stringify orderedSet 1`] = `"{\"data\":[10,9,8,7,6,5,4,3,2,1],\"__serializedType__\":\"ImmutableOrderedSet\"}"`;
 

--- a/test/immutable.spec.js
+++ b/test/immutable.spec.js
@@ -6,7 +6,9 @@ var parse = serialize.parse;
 
 var data = {
   map: Immutable.Map({ a: 1, b: 2, c: 3, d: 4 }),
+  'numeric keys map': Immutable.Map([ [ 1, 'one'], [ 2, 'two' ], [ 3, 'three' ] ]),
   orderedMap: Immutable.OrderedMap({ b: 2, a: 1, c: 3, d: 4 }),
+  'numeric keys OrderedMap': Immutable.OrderedMap([ [ 1, 'one'], [ 2, 'two' ], [ 3, 'three' ] ]),
   list: Immutable.List([1,2,3,4,5,6,7,8,9,10]),
   range: Immutable.Range(0,7),
   repeat: Immutable.Repeat('hi', 100),
@@ -57,6 +59,7 @@ describe('Immutable', function () {
   describe('Nested', function () {
     var ABRecord = Immutable.Record({
       map: Immutable.OrderedMap({ seq: data.seq, stack: data.stack }),
+      numeric_map: Immutable.Map([ [ 1, data.seq ], [ 2, data.stack ] ]),
       repeat: data.repeat
     });
     var nestedData = Immutable.Set(ABRecord(), data.orderedSet, data.range);


### PR DESCRIPTION
Serialize Map and OrderedMap as arrays of tuples instead of a native JS object in order to add support for numeric keys.

Fixes #8.