### PR TITLE
Custom replacer and reviver functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,39 @@ console.log(Immutable.is(parsed, myRecord));
 // true
 ```
 
+### Passing custom serialization functions
+
+You can pass custom replacer and reviver functions to Serialize:
+
+```js
+import Immutable from 'immutable';
+import Serialize from 'remotedev-serialize';
+
+function customReplacer(key, value, defaultReplacer) {
+  if (value === 1) {
+    return { data: 'one', __serializedType__: 'number' };
+  }
+  return defaultReplacer(key, value);
+}
+
+function customReviver(key, value, defaultReviver) {
+  if (typeof value === 'object' && value.__serializedType__ === 'number' && value.data === 'one') {
+    return 1;
+  }
+  return defaultReviver(key, value);
+}
+
+const { stringify, parse } =  Serialize.immutable(Immutable, null, customReplacer, customReviver);
+
+const map = Immutable.Map({ a:1, b:2 });
+const serialized = stringify(map);
+console.log(serialized);
+// {"data":{"a":{"data":"one","__serializedType__":"number"},"b":2},"__serializedType__":"ImmutableMap"}
+const parsed = parse(serialized);
+console.log(Immutable.is(parsed, map));
+// true
+```
+
 ### Supported
 
 #### ImutableJS

--- a/immutable/index.js
+++ b/immutable/index.js
@@ -2,13 +2,21 @@ var jsan = require('jsan');
 var serialize = require('./serialize');
 var options= require('../constants/options');
 
-module.exports = function(Immutable, refs) {
+module.exports = function(Immutable, refs, customReplacer, customReviver) {
   return {
     stringify: function(data) {
-      return jsan.stringify(data, serialize(Immutable, refs).replacer, null, options);
+      return jsan.stringify(
+        data,
+        serialize(Immutable, refs, customReplacer, customReviver).replacer,
+        null,
+        options
+      );
     },
     parse: function(data) {
-      return jsan.parse(data, serialize(Immutable, refs).reviver);
+      return jsan.parse(
+        data,
+        serialize(Immutable, refs, customReplacer, customReviver).reviver
+      );
     },
     serialize: serialize
   }

--- a/immutable/serialize.js
+++ b/immutable/serialize.js
@@ -4,44 +4,55 @@ var extract = helpers.extract;
 var refer = helpers.refer;
 var options= require('../constants/options');
 
-module.exports = function serialize(Immutable, refs) {
-  return {
-    replacer: function(key, value) {
-      if (value instanceof Immutable.Record) return refer(value, 'ImmutableRecord', 'toObject', refs);
-      if (value instanceof Immutable.Range) return extract(value, 'ImmutableRange');
-      if (value instanceof Immutable.Repeat) return extract(value, 'ImmutableRepeat');
-      if (Immutable.OrderedMap.isOrderedMap(value)) return mark(value, 'ImmutableOrderedMap', 'toObject');
-      if (Immutable.Map.isMap(value)) return mark(value, 'ImmutableMap', 'toObject');
-      if (Immutable.List.isList(value)) return mark(value, 'ImmutableList', 'toArray');
-      if (Immutable.OrderedSet.isOrderedSet(value)) return mark(value, 'ImmutableOrderedSet', 'toArray');
-      if (Immutable.Set.isSet(value)) return mark(value, 'ImmutableSet', 'toArray');
-      if (Immutable.Seq.isSeq(value)) return mark(value, 'ImmutableSeq', 'toArray');
-      if (Immutable.Stack.isStack(value)) return mark(value, 'ImmutableStack', 'toArray');
-      return value;
-    },
+module.exports = function serialize(Immutable, refs, customReplacer, customReviver) {
+  function replacer(key, value) {
+    if (value instanceof Immutable.Record) return refer(value, 'ImmutableRecord', 'toObject', refs);
+    if (value instanceof Immutable.Range) return extract(value, 'ImmutableRange');
+    if (value instanceof Immutable.Repeat) return extract(value, 'ImmutableRepeat');
+    if (Immutable.OrderedMap.isOrderedMap(value)) return mark(value, 'ImmutableOrderedMap', 'toObject');
+    if (Immutable.Map.isMap(value)) return mark(value, 'ImmutableMap', 'toObject');
+    if (Immutable.List.isList(value)) return mark(value, 'ImmutableList', 'toArray');
+    if (Immutable.OrderedSet.isOrderedSet(value)) return mark(value, 'ImmutableOrderedSet', 'toArray');
+    if (Immutable.Set.isSet(value)) return mark(value, 'ImmutableSet', 'toArray');
+    if (Immutable.Seq.isSeq(value)) return mark(value, 'ImmutableSeq', 'toArray');
+    if (Immutable.Stack.isStack(value)) return mark(value, 'ImmutableStack', 'toArray');
+    return value;
+  }
 
-    reviver: function(key, value) {
-      if (typeof value === 'object' && value !== null && '__serializedType__'  in value) {
-        var data = value.data;
-        switch (value.__serializedType__) {
-          case 'ImmutableMap': return Immutable.Map(data);
-          case 'ImmutableOrderedMap': return Immutable.OrderedMap(data);
-          case 'ImmutableList': return Immutable.List(data);
-          case 'ImmutableRange': return Immutable.Range(data._start, data._end, data._step);
-          case 'ImmutableRepeat': return Immutable.Repeat(data._value, data.size);
-          case 'ImmutableSet': return Immutable.Set(data);
-          case 'ImmutableOrderedSet': return Immutable.OrderedSet(data);
-          case 'ImmutableSeq': return Immutable.Seq(data);
-          case 'ImmutableStack': return Immutable.Stack(data);
-          case 'ImmutableRecord':
-            return refs && refs[value.__serializedRef__]
-              ? new refs[value.__serializedRef__](data)
-              : Immutable.Map(data);
-          default: return data;
-        }
+  function reviver(key, value) {
+    if (typeof value === 'object' && value !== null && '__serializedType__'  in value) {
+      var data = value.data;
+      switch (value.__serializedType__) {
+        case 'ImmutableMap': return Immutable.Map(data);
+        case 'ImmutableOrderedMap': return Immutable.OrderedMap(data);
+        case 'ImmutableList': return Immutable.List(data);
+        case 'ImmutableRange': return Immutable.Range(data._start, data._end, data._step);
+        case 'ImmutableRepeat': return Immutable.Repeat(data._value, data.size);
+        case 'ImmutableSet': return Immutable.Set(data);
+        case 'ImmutableOrderedSet': return Immutable.OrderedSet(data);
+        case 'ImmutableSeq': return Immutable.Seq(data);
+        case 'ImmutableStack': return Immutable.Stack(data);
+        case 'ImmutableRecord':
+          return refs && refs[value.__serializedRef__]
+            ? new refs[value.__serializedRef__](data)
+            : Immutable.Map(data);
+        default: return data;
       }
-      return value;
-    },
+    }
+    return value;
+  }
+
+  return {
+    replacer: customReplacer
+      ? function(key, value) {
+        return customReplacer(key, value, replacer);
+      }
+      : replacer,
+    reviver: customReviver
+      ? function(key, value) {
+        return customReviver(key, value, reviver);
+      }
+      : reviver,
     options: options
   }   
 };


### PR DESCRIPTION
I created a fork and added support of custom replacer and reviver functions for my own needs. My use case is deserializing symbols in such a way that equality comparisons continue to work after serialization and deserialization. I offer a pull request in case you find this functionality useful.