### PR TITLE
fix: OrderedMap are now keept in order when serialized.

### DIFF
--- a/helpers/index.js
+++ b/helpers/index.js
@@ -12,12 +12,19 @@ function extract(data, type) {
   };
 }
 
+function extractArray(data, type, transformMethod) {
+  return {
+    data: Array.from(transformMethod ? data[transformMethod]() : data),
+    __serializedType__: type
+  };
+}
+
 function refer(data, type, isArray, refs) {
   var r = mark(data, type, isArray);
   if (!refs) return r;
   for (var i = 0; i < refs.length; i++) {
     var ref = refs[i];
-    if (typeof ref === 'function' && data instanceof ref) {
+    if (typeof ref === "function" && data instanceof ref) {
       r.__serializedRef__ = i;
       return r;
     }
@@ -28,5 +35,6 @@ function refer(data, type, isArray, refs) {
 module.exports = {
   mark: mark,
   extract: extract,
+  extractArray: extractArray,
   refer: refer
 };

--- a/immutable/serialize.js
+++ b/immutable/serialize.js
@@ -1,6 +1,7 @@
 var helpers = require('../helpers');
 var mark = helpers.mark;
 var extract = helpers.extract;
+var extractArray = helpers.extractArray;
 var refer = helpers.refer;
 var options= require('../constants/options');
 
@@ -9,7 +10,7 @@ module.exports = function serialize(Immutable, refs, customReplacer, customReviv
     if (value instanceof Immutable.Record) return refer(value, 'ImmutableRecord', 'toObject', refs);
     if (value instanceof Immutable.Range) return extract(value, 'ImmutableRange');
     if (value instanceof Immutable.Repeat) return extract(value, 'ImmutableRepeat');
-    if (Immutable.OrderedMap.isOrderedMap(value)) return mark(value, 'ImmutableOrderedMap', 'toObject');
+    if (Immutable.OrderedMap.isOrderedMap(value)) return extractArray(value, 'ImmutableOrderedMap', 'entries');
     if (Immutable.Map.isMap(value)) return mark(value, 'ImmutableMap', 'toObject');
     if (Immutable.List.isList(value)) return mark(value, 'ImmutableList', 'toArray');
     if (Immutable.OrderedSet.isOrderedSet(value)) return mark(value, 'ImmutableOrderedSet', 'toArray');

--- a/test/__snapshots__/helpers.spec.js.snap
+++ b/test/__snapshots__/helpers.spec.js.snap
@@ -7,6 +7,33 @@ Object {
 }
 `;
 
+exports[`Helpers extractArray 1`] = `
+Object {
+  "__serializedType__": "testType",
+  "data": Array [
+    "Test",
+    "Data",
+  ],
+}
+`;
+
+exports[`Helpers extractArray 2`] = `
+Object {
+  "__serializedType__": "testType",
+  "data": Array [
+    "T",
+    "e",
+    "s",
+    "t",
+    ",",
+    "D",
+    "a",
+    "t",
+    "a",
+  ],
+}
+`;
+
 exports[`Helpers mark 1`] = `
 Object {
   "__serializedType__": "testType",

--- a/test/__snapshots__/immutable.spec.js.snap
+++ b/test/__snapshots__/immutable.spec.js.snap
@@ -1,4 +1,4 @@
-exports[`Immutable Nested stringify 1`] = `"{\"data\":[[\"map\",{\"data\":{\"seq\":{\"data\":[1,2,3,4,5,6,7,8],\"__serializedType__\":\"ImmutableSeq\"},\"stack\":{\"data\":[\"a\",\"b\",\"c\"],\"__serializedType__\":\"ImmutableStack\"}},\"__serializedType__\":\"ImmutableOrderedMap\"}],[\"repeat\",{\"data\":{\"_value\":\"hi\",\"size\":100},\"__serializedType__\":\"ImmutableRepeat\"}]],\"__serializedType__\":\"ImmutableSet\"}"`;
+exports[`Immutable Nested stringify 1`] = `"{\"data\":[[\"map\",{\"data\":[[\"seq\",{\"data\":[1,2,3,4,5,6,7,8],\"__serializedType__\":\"ImmutableSeq\"}],[\"stack\",{\"data\":[\"a\",\"b\",\"c\"],\"__serializedType__\":\"ImmutableStack\"}]],\"__serializedType__\":\"ImmutableOrderedMap\"}],[\"repeat\",{\"data\":{\"_value\":\"hi\",\"size\":100},\"__serializedType__\":\"ImmutableRepeat\"}]],\"__serializedType__\":\"ImmutableSet\"}"`;
 
 exports[`Immutable Record stringify 1`] = `"{\"data\":{\"a\":1,\"b\":3},\"__serializedType__\":\"ImmutableRecord\",\"__serializedRef__\":0}"`;
 
@@ -6,7 +6,7 @@ exports[`Immutable Stringify list 1`] = `"{\"data\":[1,2,3,4,5,6,7,8,9,10],\"__s
 
 exports[`Immutable Stringify map 1`] = `"{\"data\":{\"a\":1,\"b\":2,\"c\":3,\"d\":4},\"__serializedType__\":\"ImmutableMap\"}"`;
 
-exports[`Immutable Stringify orderedMap 1`] = `"{\"data\":{\"b\":2,\"a\":1,\"c\":3,\"d\":4},\"__serializedType__\":\"ImmutableOrderedMap\"}"`;
+exports[`Immutable Stringify orderedMap 1`] = `"{\"data\":[[\"b\",2],[\"a\",1],[\"c\",3],[\"d\",4]],\"__serializedType__\":\"ImmutableOrderedMap\"}"`;
 
 exports[`Immutable Stringify orderedSet 1`] = `"{\"data\":[10,9,8,7,6,5,4,3,2,1],\"__serializedType__\":\"ImmutableOrderedSet\"}"`;
 

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -1,6 +1,7 @@
 var helpers = require('../helpers');
 var mark = helpers.mark;
 var extract = helpers.extract;
+var extractArray = helpers.extractArray;
 var refer = helpers.refer;
 
 describe('Helpers', function () {
@@ -13,9 +14,15 @@ describe('Helpers', function () {
     expect(extract({ testData: 'test' }, 'testType')).toMatchSnapshot();
   });
 
+  it('extractArray', function() {
+    expect(extractArray([ 'Test', 'Data' ], 'testType')).toMatchSnapshot();
+    expect(extractArray([ 'Test', 'Data' ], 'testType', 'toString')).toMatchSnapshot();
+  });
+
   it('refer', function() {
     var TestClass = function(data) { return data; };
     var testInstance = new TestClass({ testData: 'test' });
     expect(refer(testInstance, 'testType', false, [TestClass])).toMatchSnapshot();
   });
+
 });


### PR DESCRIPTION
I had a problem using this lib with immutable OrderedMap: with lots of data, serialization did not keep the order of each item.
This happened because OrderedMap was serialized using `toObject` which does not necessarily keep the items in order. 

OrderedMap is now serialized using the `entries` method which conserve order. Had to add an `extractArray` helper, because `entries` returns an iterator.

A simpler fix using Immutable v4 would be to use the `toArray`, but it does not work with v3, as the method returns only the values.
